### PR TITLE
feat: Setup AppCoordinator as application entry point

### DIFF
--- a/Shopflow/Coordinators/AppCoordinator.swift
+++ b/Shopflow/Coordinators/AppCoordinator.swift
@@ -1,0 +1,21 @@
+//
+//  AppCoordinator.swift
+//  Shopflow
+//
+//  Created by Rodrigo Cerqueira Reis on 26/09/25.
+//
+
+import Foundation
+import UIKit
+
+final class AppCoordinator: Coordinator {
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+    }
+}

--- a/Shopflow/Coordinators/Coordinator.swift
+++ b/Shopflow/Coordinators/Coordinator.swift
@@ -1,0 +1,14 @@
+//
+//  Coordinator.swift
+//  Shopflow
+//
+//  Created by Rodrigo Cerqueira Reis on 26/09/25.
+//
+
+import Foundation
+import UIKit
+
+protocol Coordinator {
+    var navigationController: UINavigationController { get set }
+    func start()
+}

--- a/Shopflow/SceneDelegate.swift
+++ b/Shopflow/SceneDelegate.swift
@@ -10,18 +10,22 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    private var appCoordinator: AppCoordinator?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
-        window = UIWindow(windowScene: windowScene)
+        let window = UIWindow(windowScene: windowScene)
+        let navigationController = UINavigationController()
+        let coordinator = AppCoordinator(navigationController: navigationController)
         
-        let viewController = UIViewController()
-        viewController.view.backgroundColor = .blue
-
-        window?.rootViewController = viewController
-        window?.makeKeyAndVisible()
+        coordinator.start()
+        window.rootViewController = navigationController
+        
+        self.appCoordinator = coordinator
+        self.window = window
+        
+        window.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
## 📝 Description

This Pull Request establishes the foundational navigation architecture for the application, the MVVM-C pattern. It removes the Storyboard-based launch and replaces it with a programmatic flow controlled by the `AppCoordinator`, which now serves as the main entry point for the UI.

This work addresses the initial setup required to build a scalable and testable application from the ground up.

## 🚀 Changes

- **View Code Configuration:** The `Main.storyboard` file was deleted, and all references were removed from the project configuration (`Info.plist`, Target settings).
- **Coordinator Protocol:** A base protocol (`Coordinator.swift`) was created to define a common contract for all future coordinators, promoting decoupling and adhering to the Dependency Inversion Principle.
- **`AppCoordinator` Implementation:** The `final class AppCoordinator` was created to own and manage the application's main `UINavigationController`.
- **`SceneDelegate` Integration:** The `SceneDelegate` was refactored to instantiate and start the `AppCoordinator` on launch, injecting the `UINavigationController` and setting it as the window's `rootViewController`.

## ✅ How to Test

1.  Check out this branch.
2.  Build and run the application (`Cmd + R`).
3.  **Expected Result:** The app should launch without any crashes, displaying a screen with a navigation bar at the top. This confirms that the `UINavigationController` managed by the `AppCoordinator` is the root view and is ready to manage a view controller stack.
